### PR TITLE
Emit ENOTDIR on opendir when appropriate

### DIFF
--- a/lib/Test/MockFile.pm
+++ b/lib/Test/MockFile.pm
@@ -1217,6 +1217,11 @@ BEGIN {
             return undef;
         }
 
+        if ( !( $mock_dir->{'mode'} & S_IFDIR ) ) {
+            $! = ENOTDIR;
+            return undef;
+        }
+
         if ( !defined $_[0] ) {
             $_[0] = Symbol::gensym;
         }


### PR DESCRIPTION
Currently, the mocked `opendir()` does not error out when the filesystem object being acted upon is not a directory. This implements the proper behavior of returning `undef` and setting `$!` to `ENOTDIR`. It also updates the tests accordingly.