### PR TITLE
GH #47: Manage bareword filehandles in runtime:

### DIFF
--- a/lib/Test/MockFile.pm
+++ b/lib/Test/MockFile.pm
@@ -135,6 +135,38 @@ BEGIN {
     );
 }
 
+# If we're dealing with a bareword, it's actually a string
+# However, that string should be available as a typeglob with an IO
+# So, theoretically, we can fetch it and see if it works
+# (What happens if someone sends a string of a package glob?)
+sub _upgrade_barewords {
+    my @args = @_;
+
+    # Ignore unnecessary calls
+    @_ == 0
+        and return;
+
+    # Ignore handles
+    ref $args[0]
+        and return @args;
+
+    # Upgrade the handle
+    my $handle;
+    {
+        no strict 'refs';
+        $handle = *{ $args[0] };
+    }
+
+    # Check that the upgrading worked
+    ref \$handle eq 'GLOB'
+        or return @args;
+
+    # Override original handle variable/string
+    $args[0] = $handle;
+
+    return @args;
+}
+
 sub _strict_mode_violation {
     my ( $command, $at_under_ref ) = @_;
 
@@ -1195,6 +1227,8 @@ BEGIN {
     };
 
     *CORE::GLOBAL::opendir = sub(*$) {
+        @_ = _upgrade_barewords(@_) if defined $_[0];
+
         my $mock_dir = _get_file_object( $_[1] );
 
         # 1 arg Opendir doesn't work??
@@ -1240,6 +1274,8 @@ BEGIN {
     };
 
     *CORE::GLOBAL::readdir = sub(*) {
+        @_ = _upgrade_barewords(@_) if defined $_[0];
+
         my $mocked_dir = _get_file_object( $_[0] );
 
         if ( !$mocked_dir ) {
@@ -1276,6 +1312,8 @@ BEGIN {
     };
 
     *CORE::GLOBAL::telldir = sub(*) {
+        @_ = _upgrade_barewords(@_) if defined $_[0];
+
         my ($fh) = @_;
         my $mocked_dir = _get_file_object($fh);
 
@@ -1298,6 +1336,8 @@ BEGIN {
     };
 
     *CORE::GLOBAL::rewinddir = sub(*) {
+        @_ = _upgrade_barewords(@_) if defined $_[0];
+
         my ($fh) = @_;
         my $mocked_dir = _get_file_object($fh);
 
@@ -1321,6 +1361,8 @@ BEGIN {
     };
 
     *CORE::GLOBAL::seekdir = sub(*$) {
+        @_ = _upgrade_barewords(@_) if defined $_[0];
+
         my ( $fh, $goto ) = @_;
         my $mocked_dir = _get_file_object($fh);
 
@@ -1343,6 +1385,8 @@ BEGIN {
     };
 
     *CORE::GLOBAL::closedir = sub(*) {
+        @_ = _upgrade_barewords(@_) if defined $_[0];
+
         my ($fh) = @_;
         my $mocked_dir = _get_file_object($fh);
 
@@ -1479,6 +1523,34 @@ BEGIN {
         return 1;
     };
 }
+
+=head1 BAREWORD FILEHANDLE FAILURES
+
+There is a particular type of bareword filehandle failures that cannot be
+fixed.
+
+These errors occur because there's compile-time code that uses bareword
+filehandles in a function call that cannot be expressed by this module's
+prototypes for core functions.
+
+The only solution to these is loading `Test::MockFile` after the other code:
+
+This will fail:
+
+    # This will fail because Test2::V0 will eventually load Term::Table::Util
+    # which calls open() with a bareword filehandle that is misparsed by this module's
+    # opendir prototypes
+    use Test::MockFile ();
+    use Test2::V0;
+
+This will succeed:
+
+    # This will succeed because open() will be parsed by perl
+    # and only then we override those functions
+    use Test2::V0;
+    use Test::MockFile ();
+
+(Using strict-mode will not fix it, even though you should use it.)
 
 =head1 AUTHOR
 

--- a/t/opendir.t
+++ b/t/opendir.t
@@ -38,8 +38,6 @@ is( $! + 0, ENOENT, '$! numeric is right.' );
 is( opendir( my $notdir_fh, $temp_notdir ), undef, "opendir on a file returns false" );
 is( $! + 0, ENOTDIR, '$! numeric is right.' );
 
-like( dies { readdir("abc"); }, qr/^Bad symbol for dirhandle at/, "Dies if string passed instead of dir fh" );
-
 my ( $real_fh, $f3 ) = tempfile( DIR => $temp_dir );
 like( warning { readdir($real_fh) }, qr/^readdir\(\) attempted on invalid dirhandle \$fh/, "We only warn if the file handle or glob is invalid." );
 

--- a/t/runtime-bareword-filehandles.t
+++ b/t/runtime-bareword-filehandles.t
@@ -1,0 +1,26 @@
+use strict;
+use warnings;
+
+use Test2::Bundle::Extended;
+use Test2::Tools::Explain;
+use Test2::Plugin::NoWarnings;
+use Test2::Tools::Exception qw< lives >;
+
+# This must be loaded after other modules that use open() in BEGIN
+use Test::MockFile (); # specifically not "strict" to trigger the issue
+
+# This must be loaded after Test::MockFile so we override the core functions
+# that will be used in File::Find when it compiles
+use File::Find ();
+
+ok(
+    lives( sub {
+        File::Find::find(
+            { 'wanted' => sub { 1 } },
+            '.',
+        );
+    }),
+    'Successfully handled bareword filehandles during runtime',
+);
+
+done_testing();


### PR DESCRIPTION
(What this solution does appears further down after "Context.")

Context
-------

When Test::MockFile loads, it overrides a set of core functions like open(). It uses prototypes that *should* match the same protoypes as the core functions. (`prototype("CORE::open")` is example syntax for retrieving such prototypes.

However, the prototypes are not actually the same as the parsing perl does. It's just the closest approximation that can be expressed in prototypes. that's usually not a problem, except when dealing with bareword filehandles.

There are two cases:

1. strict refs failures (runtime)
2. strict subs failures (compile-time)

Let's explore:

1. The strict refs failures are detected during runtime. A good example of it is GH #47:

```
    use Test::MockFile (); # override open
    use File::Find     (); # will use open in runtime, so no error yet

    # Call opendir() which was overridden by Test::MockFile
    # using a bareword, which causes a strict refs failure
    File::Find::find( sub {1}, '/' );

    print "Never reach here due to runtime error";

    # This is what's actually in File::Find::find():
    #   opendir DIR, ...
```

Technically, this *isn't* actually a stricture problem because `perl` will parse it correctly, but *we* cannot parse it correctly with the prototypes we use - or any prototype, really.

(It's important to note that there's another side-effect that happens here which is described below under 'What the actual issue is.')

2. The strict subs are triggered for the same issue, but when it happens during compile time. For example:

```
    # Override open()
    use Test::MockFile ();

    # Calls open() with bareword
    use Term::Table::Util ();

    print "Never reach here due to compile-time error";

    # This is what's actually in Term::Table:
    #   BEGIN { open( $IO, '>&', STDOUT or die... }
```

Here's a fun fact:

```
    # This works just fine
    open my $fh, '>&', STDOUT;

    # This fails with strict
    open my $fh, '>', STDOUT;
```

This shows that the parsing rules are not consistent and cannot be expressed with prototypes. That is, they should both fail on strict but `perl` will understand the `STDOUT` in the first version.

There's nothing we can do about this type of error. This is because of the actual underlying issue described below. There's nothing that we can do about it, other than loading `Test::MockFile` at the end.

What the actual issue is
------------------------

The following order of events happens:

* `Test::MockFile` is loaded
* `Test::MockFile` overrides core functions like `open`, `opendir`, etc.
* A module, like `File::Find`, is loaded
* `File::Find::find()` will call `opendir DIR` which is a bareword filehandle
* Our `opendir()` function will be called, but because of the parsing rules, the argument we will receive is the string `DIR`.
* We will send this string to `CORE::opendir()` which will get mad because it cannot use that string. It mentions the user's code as the caller because we use `goto &CORE::open` which will remove *us* from the calling stack.

This means our issue is that our code will receive the bareword (like `STDOUT`) as a string (`"STDOUT"`) and then we pass *that* to the core `open()` function.

This is why any function call that is parsed correctly (and sends us the bareword as a string) can be fixed and any function call that now cannot be parsed correctly (because our prototypes are not enough) cannot be fixed.

Solution
--------

Barewords are essentially evaluated as strings and then looked up as a typeglob with an 'IO' entry.

What we do is try to figure out if this is a bareword filehandle by looking up a typeglob with the string representing the variable name and if that works, we use that instead.

This is slightly tricky and I wish I could make it even more specific by checking for an IO entry. However, when this is mocked, it's a bit trickier and the `IO` slot will not be available.