### PR TITLE
GH #40: Support GLOBAL::glob():

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -20,6 +20,7 @@ WriteMakefile(
         'Test2::Tools::Explain'     => '0',
         'Test2::Plugin::NoWarnings' => '0',
         'File::Slurper'             => 0,
+        'Text::Glob'                => 0,
     },
     PREREQ_PM => {
         'Overload::FileCheck' => '0.007',

--- a/cpanfile
+++ b/cpanfile
@@ -1,6 +1,10 @@
 # kind of duplicate of Makefile.PL
 #	but convenient for Continuous Integration
 
+on 'build' => sub {
+    requires 'Text::Glob' => 0;
+};
+
 on 'test' => sub {
     requires 'Test::More'      => 0;
     requires 'Test2::Bundle::Extended' => 0;

--- a/t/globbing.t
+++ b/t/globbing.t
@@ -1,0 +1,72 @@
+use strict;
+use warnings;
+
+use Test2::Bundle::Extended;
+use Test2::Tools::Explain;
+use Test2::Plugin::NoWarnings;
+use Test::MockFile qw< strict >;
+# use Text::Glob ();
+
+my $file1 = Test::MockFile->file('/file1.txt');
+my $file2 = Test::MockFile->file('/file2.txt');
+my $file3 = Test::MockFile->file('/file3.jpg');
+my $file4 = Test::MockFile->file('/dir1/file4.txt');
+my $file5 = Test::MockFile->file('/dir2/file5.jpg');
+my $file6 = Test::MockFile->file('/dir3/dir4/file6.jpg');
+my $dir5  = Test::MockFile->dir('/dir3/dir5');
+
+my @tests = (
+    [ [qw< /file1.txt /file2.txt >],            '/*.txt' ],
+    [ [qw< /file1.txt /file2.txt /file3.jpg >], '/*.{txt,jp{g}}' ],
+    [ [qw< /file1.txt /file2.txt /file3.jpg >], '/*.txt /*.jpg' ],
+
+    [
+        [ '/dir1/file4.txt', '/dir2/file5.jpg', '/dir3/dir4', '/dir3/dir5' ],
+        '/*/*'
+    ],
+);
+
+is(
+    [ glob( '/*.txt' ) ],
+    $tests[0][0],
+    'glob(' . $tests[0][1] . ')',
+);
+
+is(
+    [ </*.txt> ],
+    $tests[0][0],
+    '<' . $tests[0][1] . '>',
+);
+
+is(
+    [ glob('/*.{txt,jp{g}}') ],
+    $tests[1][0],
+    'glob(' . $tests[1][1] . ')',
+);
+
+is(
+    [ </*.{txt,jp{g}}> ],
+    $tests[1][0],
+    '<' . $tests[1][1] . '>',
+);
+
+is(
+    [ </*.txt /*.jpg> ], # / (fix syntax highlighting on vim)
+    $tests[2][0],
+    '<' . $tests[2][1] . '>',
+);
+
+is(
+    [ glob( '/*.txt /*.jpg') ],
+    $tests[2][0],
+    'glob(' . $tests[2][1] . ')',
+);
+
+is(
+    [ </*/*> ], # / (fix syntax highlighting on vim)
+    $tests[3][0],
+    '<' . $tests[3][1] . '>',
+);
+
+done_testing();
+exit;


### PR DESCRIPTION
If you now try glob, either by `glob()` or `<...>`, it will use theavailable files and directories to achieve it.

It's using Text::Glob under the hood, but adds support for two additional behaviors of Perl that Text::Glob does not support.