### PR TITLE
Implementing glob

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -20,6 +20,7 @@ WriteMakefile(
         'Test2::Tools::Explain'     => '0',
         'Test2::Plugin::NoWarnings' => '0',
         'File::Slurper'             => 0,
+        'Text::Glob'                => 0,
     },
     PREREQ_PM => {
         'Overload::FileCheck' => '0.007',

--- a/cpanfile
+++ b/cpanfile
@@ -1,6 +1,10 @@
 # kind of duplicate of Makefile.PL
 #	but convenient for Continuous Integration
 
+on 'build' => sub {
+    requires 'Text::Glob' => 0;
+};
+
 on 'test' => sub {
     requires 'Test::More'      => 0;
     requires 'Test2::Bundle::Extended' => 0;

--- a/lib/Test/MockFile.pm
+++ b/lib/Test/MockFile.pm
@@ -27,6 +27,7 @@ use Cwd                        ();
 use IO::File                   ();
 use Test::MockFile::FileHandle ();
 use Test::MockFile::DirHandle  ();
+use Text::Glob                 ();
 use Scalar::Util               ();
 
 use Symbol;
@@ -103,6 +104,10 @@ A strict mode is even provided which can throw a die when files are accessed dur
     
     # The file check will now happen on file system now the file is no longer mocked.
     say 'ok' if !-e '/foo/baz';
+
+    my $quux    = Test::MockFile->file('/foo/bar/quux.txt');
+    my @matches = </foo/bar/*.txt>;       # ( 'quux.txt' )
+    my @matches = glob('/foo/bar/*.txt'); # same as above
 
 =head1 IMPORT
 
@@ -1191,6 +1196,25 @@ sub _goto_is_available {
 }
 
 BEGIN {
+    *CORE::GLOBAL::glob = sub (_;) {
+        my $spec = shift;
+
+        # Text::Glob does not understand multiple patterns
+        my @patterns = split /\s+/xms, $spec;
+
+        # Text::Glob does not accept directories in globbing
+        # But csh (and thus, Perl) does, so we need to add them
+        my @mocked_files = grep $files_being_mocked{$_}->exists(), keys %files_being_mocked;
+
+        @mocked_files = map /^(.+)\/[^\/]+$/xms ? ( $_, $1 ) : ($_), @mocked_files;
+
+        # Might as well be consistent
+        @mocked_files = sort @mocked_files;
+
+        my @results = map Text::Glob::match_glob( $_, @mocked_files ), @patterns;
+        return @results;
+    };
+
     *CORE::GLOBAL::open = sub(*;$@) {
         my $likely_bareword;
         my $arg0;

--- a/t/globbing.t
+++ b/t/globbing.t
@@ -1,0 +1,108 @@
+use strict;
+use warnings;
+
+use Test2::Bundle::Extended;
+use Test2::Tools::Explain;
+use Test2::Plugin::NoWarnings;
+use Test::MockFile qw< strict >;
+
+my $file1 = Test::MockFile->file('/file1.txt');
+my $file2 = Test::MockFile->file('/file2.txt');
+my $file3 = Test::MockFile->file('/file3.jpg');
+my $file4 = Test::MockFile->file('/dir1/file4.txt');
+my $file5 = Test::MockFile->file('/dir2/file5.jpg');
+my $file6 = Test::MockFile->file('/dir3/dir4/file6.jpg');
+my $dir5  = Test::MockFile->dir('/dir3/dir5');
+
+my @tests = (
+    [ [qw< /file1.txt /file2.txt >],            '/*.txt' ],
+    [ [qw< /file1.txt /file2.txt /file3.jpg >], '/*.{txt,jp{g}}' ],
+    [ [qw< /file1.txt /file2.txt /file3.jpg >], '/*.txt /*.jpg' ],
+
+    [
+        [ '/dir1/file4.txt', '/dir2/file5.jpg', '/dir3/dir4' ],
+        '/*/*'
+    ],
+
+    [
+        [ '/dir1/file4.txt', '/dir2/file5.jpg', '/dir3/dir4', '/dir3/dir5' ],
+        '/*/*'
+    ],
+);
+
+is(
+    [ glob('/*.txt') ],
+    [],
+    'glob(' . $tests[0][1] . ')',
+);
+
+is(
+    [ </*.txt> ],
+    [],
+    '<' . $tests[0][1] . '>',
+);
+
+$file1->contents('1');
+$file2->contents('2');
+$file3->contents('3');
+$file4->contents('4');
+$file5->contents('5');
+$file6->contents('6');
+
+is(
+    [ glob('/*.txt') ],
+    $tests[0][0],
+    'glob(' . $tests[0][1] . ')',
+);
+
+is(
+    [ </*.txt> ],
+    $tests[0][0],
+    '<' . $tests[0][1] . '>',
+);
+
+is(
+    [ glob('/*.{txt,jp{g}}') ],
+    $tests[1][0],
+    'glob(' . $tests[1][1] . ')',
+);
+
+is(
+    [ </*.{txt,jp{g}}> ],
+    $tests[1][0],
+    '<' . $tests[1][1] . '>',
+);
+
+is(
+    [ </*.txt /*.jpg> ], # / (fix syntax highlighting on vim)
+    $tests[2][0],
+    '<' . $tests[2][1] . '>',
+);
+
+is(
+    [ glob( '/*.txt /*.jpg') ],
+    $tests[2][0],
+    'glob(' . $tests[2][1] . ')',
+);
+
+is(
+    [ </*/*> ], # / (fix syntax highlighting on vim)
+    $tests[3][0],
+    '<' . $tests[3][1] . '>',
+);
+
+my $top_dir3 = Test::MockFile->dir('/dir3');
+ok( -d '/dir3', 'Directory now exists' );
+
+ok( !-d '/dir3/dir5', 'Directory does not exist' );
+ok( mkdir('/dir3/dir5'), 'Created directory successfully' );
+ok( -d '/dir3/dir5', 'Directory now exists' );
+
+is(
+    [ </*/*> ], # / (fix syntax highlighting on vim)
+    $tests[4][0],
+    '<' . $tests[4][1] . '>',
+);
+
+done_testing();
+exit;


### PR DESCRIPTION
```
my $file1 = Test::MockFile->file('/dir1/file1');
my $file2 = Test::MockFile->file( '/dir2/file2', 'my content' );
my $dir3  = Test::MockFile->dir('/dir3');

my @files = glob('*/*'); # /dir2/file2
@files    = <*/*>; # same as above

$file1->contents('stuff');
@files = glob('*/*'); # /dir1/file1 /dir2/file2

my @dirs = glob('*'); # /dir1 /dir2
mkdir '/dir3';
@dirs = glob('*'); # /dir1 /dir2 /dir3
```