### PR TITLE
chown() and chmod()

### DIFF
--- a/lib/Test/MockFile.pm
+++ b/lib/Test/MockFile.pm
@@ -89,19 +89,19 @@ A strict mode is even provided which can throw a die when files are accessed dur
     my $missing_mocked_file = Test::MockFile->file('/foo/baz'); # File starts out missing
     my $opened              = open my $baz_fh, '<', '/foo/baz'; # File reports as missing so fails
     say 'ok' if !-e '/foo/baz';
-    
+
     open $baz_fh, '>', '/foo/baz' or die; # open for writing
     print {$baz_fh} "replace contents\n";
-    
+
     open $baz_fh, '>>', '/foo/baz' or die; # open for append.
     print {$baz_fh} "second line";
     close $baz_fh;
-    
+
     say $baz->contents;
-    
+
     # Unmock your file.
     undef $missing_mocked_file;
-    
+
     # The file check will now happen on file system now the file is no longer mocked.
     say 'ok' if !-e '/foo/baz';
 
@@ -122,7 +122,7 @@ For example:
     my $symlink = Test::MockFile->symlink("/foo", "/bar");
     -l '/foo' or print "ok\n";
     open my $fh, '>', '/foo';
-    
+
     # All of these will die
     open my $fh, '>', '/unmocked/file'; # Dies
     sysopen my $fh, '/other/file', O_RDONLY;
@@ -461,7 +461,7 @@ sub dir {
     my $perms = S_IFPERMS & 0777;
     my %stats = ( 'mode' => ( $perms ^ umask ) | S_IFDIR );
 
-    # TODO: Add uid, gid, etc. for the user
+    # TODO: Add stat information
 
     # FIXME: Quick and dirty: provide a helper method?
     my $has_content = grep m{^\Q$dir_name/\E}xms, %files_being_mocked;
@@ -478,13 +478,13 @@ sub dir {
 
 When creating mocked files or directories, we default their stats to:
 
-    my $mattrs = Test::MockFile->file( $file, $contents, {
+    my $attrs = Test::MockFile->file( $file, $contents, {
             'dev'       => 0,        # stat[0]
             'inode'     => 0,        # stat[1]
             'mode'      => $mode,    # stat[2]
             'nlink'     => 0,        # stat[3]
-            'uid'       => 0,        # stat[4]
-            'gid'       => 0,        # stat[5]
+            'uid'       => int $>,   # stat[4]
+            'gid'       => int $),   # stat[5]
             'rdev'      => 0,        # stat[6]
             'atime'     => $now,     # stat[8]
             'mtime'     => $now,     # stat[9]
@@ -492,7 +492,7 @@ When creating mocked files or directories, we default their stats to:
             'blksize'   => 4096,     # stat[11]
             'fileno'    => undef,    # fileno()
     } );
-    
+
 You'll notice that mode, size, and blocks have been left out of this. Mode is set to 666 (for files) or 777 (for directories), xored against the current umask.
 Size and blocks are calculated based on the size of 'contents' a.k.a. the fake file.
 
@@ -503,7 +503,7 @@ When you want to override one of the defaults, all you need to do is specify tha
     my $mdir = Test::MockFile->dir("/sbin", "...", { mode => 0700 }));
 
 =head2 new
-    
+
 This class method is called by file/symlink/dir. There is no good reason to call this directly.
 
 =cut
@@ -1154,7 +1154,7 @@ If we do not control the file in question, we return C<FALLBACK_TO_REAL_OP()> wh
 Since 5.10, it has been possible to override function calls by defining them. like:
 
     *CORE::GLOBAL::open = sub(*;$@) {...}
-    
+
 Any code which is loaded B<AFTER> this happens will use the alternate open. This means you can place your C<use Test::MockFile> statement after statements you don't want to be mocked and
 there is no risk that the code will ever be altered by Test::MockFile.
 
@@ -1748,7 +1748,7 @@ Todd Rinaldo, C<< <toddr at cpan.org> >>
 
 =head1 BUGS
 
-Please report any bugs or feature requests to L<https://github.com/CpanelInc/Test-MockFile>. 
+Please report any bugs or feature requests to L<https://github.com/CpanelInc/Test-MockFile>.
 
 =head1 SUPPORT
 

--- a/t/chmod.t
+++ b/t/chmod.t
@@ -1,0 +1,138 @@
+#!/usr/bin/perl -w
+
+use strict;
+use warnings;
+
+use Test2::Bundle::Extended;
+use Test2::Tools::Explain;
+use Test2::Plugin::NoWarnings;
+use Test2::Tools::Exception qw< lives dies >;
+use Test2::Tools::Warnings qw< warning >;
+use Test::MockFile;
+
+my $filename = __FILE__;
+my $file     = Test::MockFile->file( $filename, 'whatevs' );
+
+subtest( 'Defaults' => sub {
+    my $dir_foo  = Test::MockFile->dir('/foo');
+    my $file_bar = Test::MockFile->file( '/foo/bar', 'content' );
+
+    ok( -d '/foo',    'Directory /foo exists' );
+    ok( -f '/foo/bar', 'File /foo/bar exists' );
+
+    my $dir_def_perm = sprintf '%04o', 0777 - umask;
+    is(
+        sprintf( '%04o', ( stat '/foo' )[2] & 07777 ),
+        $dir_def_perm,
+        "Directory /foo is set to $dir_def_perm",
+    );
+
+    my $file_def_perm = sprintf '%04o', 0666 - umask;
+    is(
+        sprintf( '%04o', ( stat '/foo/bar' )[2] & 07777 ),
+        $file_def_perm,
+        "File /foo/bar is set to $file_def_perm",
+    );
+});
+
+subtest( 'Changing mode (real vs. mocked)' => sub {
+    ok( CORE::mkdir('fooz'), 'Successfully created real directory' );
+    ok( CORE::chmod( 0600, 'fooz' ), 'Successfully chmod\'ed real directory' );
+    is(
+        sprintf( '%04o', ( CORE::stat('fooz') )[2] & 07777 ),
+        '0600',
+        'CORE::chmod() set the perms correctly',
+    );
+    ok( CORE::rmdir('fooz'), 'Successfully deleted real directory' );
+
+    my $dir_foo  = Test::MockFile->dir('/foo');
+    my $file_bar = Test::MockFile->file( '/foo/bar', 'content' );
+
+    ok( -d '/foo',    'Directory /foo exists' );
+    ok( -f '/foo/bar', 'File /foo/bar exists' );
+
+    chmod 0600, qw< /foo /foo/bar >;
+
+    is(
+        sprintf( '%04o', ( stat '/foo' )[2] & 07777 ),
+        '0600',
+        'Directory /foo is now set to 0600',
+    );
+
+    is(
+        sprintf( '%04o', ( stat '/foo/bar' )[2] & 07777 ),
+        '0600',
+        'File /foo/bar is now set to 0600',
+    );
+
+    chmod 0777, qw< /foo /foo/bar >;
+
+    is(
+        sprintf( '%04o', ( stat '/foo' )[2] & 07777 ),
+        '0777',
+        'Directory /foo is now set to 0600',
+    );
+
+    is(
+        sprintf( '%04o', ( stat '/foo/bar' )[2] & 07777 ),
+        '0777',
+        'File /foo/bar is now set to 0600',
+    );
+});
+
+subtest( 'Providing a string as mode mask' => sub {
+    ok( CORE::mkdir('fooz'), 'Successfully created real directory' );
+
+    my $core_chmod_res;
+
+    like(
+        warning( sub { $core_chmod_res = CORE::chmod( 'hello', 'fooz' ) } ),
+        qr/^\QArgument "hello" isn't numeric in chmod\E/xms,
+        'CORE::chmod() threw a warning when trying to numify',
+    );
+
+    ok( $core_chmod_res, 'Successfully chmod\'ed real directory' );
+
+    is( $!, '', 'No observed error' );
+    is(
+        sprintf( '%04o', ( CORE::stat('fooz') )[2] & 07777 ),
+        '0000',
+        'CORE::chmod() set the perms correctly',
+    );
+
+    ok( CORE::rmdir('fooz'), 'Successfully deleted real directory' );
+
+    # --- Mock ---
+
+    my $dir_foo = Test::MockFile->dir('/foo');
+
+    ok( !-d '/foo', 'Directory /foo does not exist' );
+
+    # If we don't zero this out, nothing else will - wtf?
+    $! = 0;
+
+    ok( mkdir('/foo'), 'Successfully created mocked directory' );
+    ok( -d '/foo', 'Directory /foo now exists' );
+
+    my $chmod_res;
+    like(
+        warning( sub { $chmod_res = chmod 'hello', '/foo' } ),
+        qr/^\QArgument "hello" isn't numeric in chmod\E/xms,
+        'chmod() threw a warning when trying to numify',
+    );
+
+    ok( $chmod_res, 'Successfully chmod\'ed real directory' );
+
+    is( $!, '', 'No observed error' );
+    is(
+        sprintf( '%04o', ( CORE::stat('/foo') )[2] & 07777 ),
+        '0000',
+        'chmod() set the perms correctly',
+    );
+
+    ok( rmdir('/foo'), 'Successfully deleted real directory' );
+    ok( ! -d '/foo',   'Directory /foo no longer exist' );
+});
+
+done_testing();
+exit;

--- a/t/chown-chmod-nostrict.t
+++ b/t/chown-chmod-nostrict.t
@@ -1,0 +1,36 @@
+#!/usr/bin/perl -w
+
+use strict;
+use warnings;
+
+use Test2::Bundle::Extended;
+use Test2::Tools::Explain;
+use Test2::Plugin::NoWarnings;
+use Test2::Tools::Exception qw< dies >;
+use Test::MockFile;
+use Cwd ();
+
+my $euid = $>;
+my $egid = int $);
+my $filename = __FILE__;
+my $file     = Test::MockFile->file( $filename, 'whatevs' );
+
+subtest( 'Unmocked files and mixing unmocked and mocked files' => sub {
+    my $mocked   = Cwd::getcwd() . "/$filename";
+    my $unmocked = '/foo_DOES_NOT_EXIST.znxc';
+
+    like(
+        dies( sub { chown -1, -1, $filename, $unmocked } ),
+        qr/^\QYou called chown() on a mix of mocked ($mocked) and unmocked files ($unmocked)\E/xms,
+        'Even without strict mode, you cannot mix mocked and unmocked files (chown)',
+    );
+
+    like(
+        dies( sub { chmod 0755, $filename, $unmocked } ),
+        qr/^\QYou called chmod() on a mix of mocked ($mocked) and unmocked files ($unmocked) \E/xms,
+        'Even without strict mode, you cannot mix mocked and unmocked files (chmod)',
+    );
+});
+
+done_testing();
+exit;

--- a/t/chown.t
+++ b/t/chown.t
@@ -1,0 +1,157 @@
+#!/usr/bin/perl -w
+
+use strict;
+use warnings;
+
+use Test2::Bundle::Extended;
+use Test2::Tools::Explain;
+use Test2::Plugin::NoWarnings;
+use Test2::Tools::Exception qw< lives dies >;
+use Test::MockFile qw< strict >;
+
+my $euid     = $>;
+my $egid     = int $);
+my $filename = __FILE__;
+my $file     = Test::MockFile->file( $filename, 'whatevs' );
+
+subtest( 'Defaults' => sub {
+    my $dir_foo  = Test::MockFile->dir('/foo');
+    my $file_bar = Test::MockFile->file( '/foo/bar', 'content' );
+
+    ok( -d '/foo',    'Directory /foo exists' );
+    ok( -f '/foo/bar', 'File /foo/bar exists' );
+
+    foreach my $path ( qw< /foo /foo/bar > ) {
+        is(
+            ( stat $path )[4],
+            $euid,
+            "$path set UID correctly to $euid",
+        );
+
+        is(
+            ( stat $path )[5],
+            $egid,
+            "$path set GID correctly to $egid",
+        );
+    }
+});
+
+subtest( 'Change ownership of file to someone else fails' => sub {
+    ok(
+        !chown(  $euid + 9999, $egid + 9999, $filename ),
+        'Cannot chown file to some high, probably unavailable, UID/GID',
+    );
+
+    is( "$!", 'Operation not permitted', 'Correct error string' );
+    is( $!+0, 1, 'Correct error code for EPERM' );
+
+    $! = 0;
+
+    ok(
+        !chown(  $euid, $egid + 9999, $filename ),
+        'Cannot chown file to some high, probably unavailable, GID',
+    );
+
+    is( "$!", 'Operation not permitted', 'Correct error string' );
+    is( $!+0, 1, 'Correct error code for EPERM' );
+
+    $! = 0;
+
+    ok(
+        !chown(  $euid + 9999, $egid, $filename ),
+        'Cannot chown file to some high, probably unavailable, UID',
+    );
+
+    is( "$!", 'Operation not permitted', 'Correct error string' );
+    is( $!+0, 1, 'Correct error code for EPERM' );
+
+    SKIP: {
+        note( "\$>: $>, int \$): " . int $) );
+        $> == 0 || grep /(^ | \s ) 0 ( \s | $)/xms, $)
+            and skip( 'Running as root cannot test failing to chown to root' => 9 );
+
+        $! = 0;
+
+        ok(
+            !chown(  0, 0, $filename ),
+            'Cannot chown file to root',
+        );
+
+        is( "$!", 'Operation not permitted', 'Correct error string' );
+        is( $!+0, 1, 'Correct error code for EPERM' );
+
+        $! = 0;
+
+        is(
+            chown(  $euid, 0, $filename ),
+            0,
+            'Cannot chown file to root GID',
+        );
+
+        is( "$!", 'Operation not permitted', 'Correct error string' );
+        is( $!+0, 1, 'Correct error code for EPERM' );
+
+        $! = 0;
+
+        is(
+            chown(  0, $egid, $filename ),
+            0,
+            'Cannot chown file to root UID',
+        );
+
+        is( "$!", 'Operation not permitted', 'Correct error string' );
+        is( $!+0, 1, 'Correct error code for EPERM' );
+    }
+});
+
+subtest( 'chown only user, only group, both' => sub {
+    ok(
+        chown(  $euid, -1, $filename ),
+        'chown\'ing file to only UID',
+    );
+
+    ok(
+        chown(  -1, $egid, $filename ),
+        'chown\'ing file to only GID',
+    );
+
+    ok(
+        chown(  $euid, $egid, $filename ),
+        'chown\'ing file to both UID and GID',
+    );
+
+});
+
+subtest( 'chown with bareword' => sub {
+    no strict;
+    my $bareword_file = Test::MockFile->file('RANDOM_FILE_THAT_WILL_NOT_EXIST');
+    ok(
+        !chown( $euid, $egid, RANDOM_FILE_THAT_WILL_NOT_EXIST),
+        'Using bareword treats it as string',
+    );
+
+    is( "$!", 'No such file or directory', 'Correct error string' );
+    is( $!+0, 2, 'Correct ENOENT error' );
+});
+
+subtest( 'chown to different group of same user' => sub {
+    # See if this user has another group available
+    # (we might be on a user that has only one group)
+    my ( $top_gid, @groups ) = split /\s+/xms, $);
+
+    # root can have $) set to "0 0"
+    my ($next_gid) = grep $_ != $top_gid, @groups;
+    $next_gid
+        or skip_all('This user only has one group');
+
+    is( $top_gid, $egid, 'Skipping the first GID' );
+    isnt( $next_gid, $egid, 'Testing a different GID' );
+
+    ok(
+        chown(  -1, $next_gid, $filename ),
+        'chown\'ing file to a different GID',
+    );
+});
+
+done_testing();
+exit;


### PR DESCRIPTION
* The commands are added to strict mode.
* In chmod(), we try to issue the right warning, but the line number we're using is right above the line that *should* issue it. I think that's okay enough.
* chown() provides granular error if you send it t directory that does not exist vs. a file. chmod() doesn't seem to do that.
* If you call chown() or chmod() on mixed set of files (some mocked, some not), it will die.

```
    my $foo = Test::MockFile->file( '/foo/bar', '' );
    chmod 0644, '/foo/bar', '/bar/baz'; # dies
    chmod 0644, '/bar/baz';             # ok without strict mode
    chmod 0644, '/bar/baz';             # dies on strict mode
```

Resolves GH #15.