### PR TITLE
Fix support for top-level directory:

### DIFF
--- a/lib/Test/MockFile.pm
+++ b/lib/Test/MockFile.pm
@@ -457,7 +457,8 @@ sub dir {
     _validate_path($dir_name);
 
     # Cleanup trailing forward slashes
-    $dir_name =~ s{[/\\]$}{}xmsg;
+    $dir_name ne '/'
+        and $dir_name =~ s{[/\\]$}{}xmsg;
 
     @_ > 2
       and confess("You cannot set stats for nonexistent dir '$dir_name'");


### PR DESCRIPTION
This regex would accidentally remove the directory path "/" because
it was not anchored to be after a character.