### PR TITLE
Fix directory instantiation when creating a symlink:

### DIFF
--- a/lib/Test/MockFile.pm
+++ b/lib/Test/MockFile.pm
@@ -366,6 +366,14 @@ sub symlink {
 
     _get_file_object($file) and confess("It looks like $file is already being mocked. We don't support double mocking yet.");
 
+    # Check if directory for this file is an object we're mocking
+    # If so, mark it now as having content
+    # which is this file or - if this file is undef, . and ..
+    ( my $dirname = $file ) =~ s{ / [^/]+ $ }{}xms;
+    if ( $files_being_mocked{$dirname} ) {
+        $files_being_mocked{$dirname}{'has_content'} = 1;
+    }
+
     return $class->new(
         {
             'path'     => $file,

--- a/t/symlink.t
+++ b/t/symlink.t
@@ -1,0 +1,44 @@
+#!/usr/bin/perl -w
+
+use strict;
+use warnings;
+
+use Test2::Bundle::Extended;
+use Test2::Tools::Explain;
+use Test2::Plugin::NoWarnings;
+use Test2::Tools::Exception qw< lives dies >;
+use Test::MockFile qw< strict >;
+
+my $dir  = Test::MockFile->dir('/foo');
+my $file = Test::MockFile->file('/bar');
+ok( !-d('/foo'), 'Directory does not exist yet' );
+
+my $symlink = Test::MockFile->symlink( '/bar', '/foo/baz' );
+ok( -d('/foo'), 'Directory now exists' );
+
+{
+    opendir my $dh, '/foo' or die $!;
+    my @content = readdir $dh;
+    closedir $dh or die $!;
+    is(
+        \@content,
+        [ qw< . .. baz > ],
+        'Directory with symlink content are correct',
+    );
+}
+
+undef $symlink;
+
+{
+    opendir my $dh, '/foo' or die $!;
+    my @content = readdir $dh;
+    closedir $dh or die $!;
+    is(
+        \@content,
+        [ qw< . .. > ],
+        'Directory no longer has symlink',
+    );
+}
+
+done_testing();
+exit 0;


### PR DESCRIPTION
This makes sure that when a symlink is created in a mocked directory,
the directory will be created.

This test will fail until GH #113 is merged because it is also a case
where we're trying to list a directory with a symlink.