### PR TITLE
Show directories in readdir:

### DIFF
--- a/lib/Test/MockFile.pm
+++ b/lib/Test/MockFile.pm
@@ -765,7 +765,7 @@ sub contents {
         my $dirname        = $self->path();
         my @existing_files = sort map {
             ( my $basename = $_->path() ) =~ s{^\Q$dirname/\E}{}xms;
-            defined $_->{'contents'} || $_->is_link() ? ($basename) : ();
+            defined $_->{'contents'} || $_->is_link() || $_->is_dir() ? ($basename) : ();
         } _files_in_dir($dirname);
 
         return [ '.', '..', @existing_files ];

--- a/t/opendir.t
+++ b/t/opendir.t
@@ -72,6 +72,7 @@ is( $! + 0,                                       ENOTDIR, '$! numeric is right.
 
 # Check symlinks appear in readdir
 my $dir_for_symlink = Test::MockFile->dir('/foo');
+my $dir_in_dir      = Test::MockFile->dir('/foo/infoo');
 my $symlink_dest    = Test::MockFile->file( '/foo/dest', '' );
 my $symlink         = Test::MockFile->symlink( '/foo/dest', '/foo/source' );
 
@@ -79,9 +80,9 @@ opendir my $sdh, '/foo' or die $!;
 my @contents = readdir $sdh;
 closedir $sdh or die $!;
 is(
-    \@contents,
-    [ qw< . .. dest source > ],
-    'Symlink appears in directory content'
+    [ sort @contents ],
+    [ qw< . .. dest infoo source > ],
+    'Symlink and directories appears in directory content'
 );
 
 done_testing();


### PR DESCRIPTION
When `opendir()` is run, it creates an object for the directory using
the content of that directory. The `contents()` method did not include
directories in the listing.

Resolves GH #105.