### PR TITLE
Do let stat() get confused with trailing forward slash:

### DIFF
--- a/lib/Test/MockFile.pm
+++ b/lib/Test/MockFile.pm
@@ -645,6 +645,8 @@ sub _find_file_or_fh {
 
     # Find the file handle or fall back to just using the abs path of $file_or_fh
     my $absolute_path_to_file = _fh_to_file($file_or_fh) // _abs_path_to_file($file_or_fh) // '';
+    $absolute_path_to_file ne '/'
+        and $absolute_path_to_file =~ s{[/\\]$}{}xmsg;
 
     # Get the pointer to the object.
     my $mock_object = $files_being_mocked{$absolute_path_to_file};

--- a/t/mock_stat.t
+++ b/t/mock_stat.t
@@ -120,5 +120,13 @@ is( Test::MockFile::_mock_stat( 'stat',  '/broken_link' ), [],                  
     is $gid, int $), 'default fid is current GID';
 }
 
+{
+    # make sure directories with trailing slash are not ignored by stat by accident
+    my $dir = Test::MockFile->dir('/quux');
+    mkdir $dir->path();
+    ok( -d( $dir->path() ), 'Directory /quux exists' );
+    ok( -d( $dir->path() . '/' ), 'Directory /quux/ also exists' );
+}
+
 done_testing();
 exit;


### PR DESCRIPTION
We should normalize any directory names when retrieving the name
so `-d /foo` and `-d /foo/` are the same.

I don't like this solution, but it works.