### PR TITLE
Do not get confused by inner directory files:

### DIFF
--- a/lib/Test/MockFile.pm
+++ b/lib/Test/MockFile.pm
@@ -768,11 +768,18 @@ sub contents {
         # Retrieve the files in this directory and removes prefix
         my $dirname        = $self->path();
         my @existing_files = sort map {
+            # strip directory from the path
             ( my $basename = $_->path() ) =~ s{^\Q$dirname/\E}{}xms;
+
+            # Is this content within another directory? strip that out
+            $basename =~ s{^( [^/]+ ) / .*}{$1}xms;
+
             defined $_->{'contents'} || $_->is_link() || $_->is_dir() ? ($basename) : ();
         } _files_in_dir($dirname);
 
-        return [ '.', '..', @existing_files ];
+        my %uniq;
+        $uniq{$_}++ for @existing_files;
+        return [ '.', '..', sort keys %uniq ];
     }
 
     # handle files

--- a/t/opendir.t
+++ b/t/opendir.t
@@ -85,5 +85,19 @@ is(
     'Symlink and directories appears in directory content'
 );
 
+{
+    my $d1 = Test::MockFile->dir('/foo2/bar');
+    my $d2 = Test::MockFile->dir('/foo2');
+    mkdir $d1->path();
+    mkdir $d2->path();
+
+    my $f = Test::MockFile->file( '/foo2/bar/baz', '' );
+
+    opendir my $dh, '/foo2' or die $!;
+    my @content = readdir $dh;
+    closedir $dh or die $!;
+    is( \@content, [ qw< . .. bar > ], 'Did not get confused by internal files' );
+}
+
 done_testing();
 exit;


### PR DESCRIPTION
We would grab all files in the directory recursively, but directory
listing should only show the directories inside it, not the files
within those directories.

In other words:

    foo/
        bar/
            baz.txt

`readdir($path_to_foo)` should show `bar`, not `bar/baz.txt`.

Resolves GH #118