### PR TITLE
Strict mode is now on by default:

### DIFF
--- a/t/Test-MockFile_file.t
+++ b/t/Test-MockFile_file.t
@@ -11,7 +11,7 @@ use Fcntl;
 
 #use Errno qw/ENOENT EBADF/;
 
-use Test::MockFile qw/strict/;    # Everything below this can have its open overridden.
+use Test::MockFile;    # Everything below this can have its open overridden.
 
 pass("Todo");
 

--- a/t/chmod.t
+++ b/t/chmod.t
@@ -8,7 +8,7 @@ use Test2::Tools::Explain;
 use Test2::Plugin::NoWarnings;
 use Test2::Tools::Exception qw< lives dies >;
 use Test2::Tools::Warnings qw< warning >;
-use Test::MockFile;
+use Test::MockFile qw< nostrict >;
 
 my $filename = __FILE__;
 my $file     = Test::MockFile->file( $filename, 'whatevs' );

--- a/t/chown-chmod-nostrict.t
+++ b/t/chown-chmod-nostrict.t
@@ -7,7 +7,7 @@ use Test2::Bundle::Extended;
 use Test2::Tools::Explain;
 use Test2::Plugin::NoWarnings;
 use Test2::Tools::Exception qw< dies >;
-use Test::MockFile;
+use Test::MockFile qw< nostrict >;
 use Cwd ();
 
 my $euid     = $>;

--- a/t/chown.t
+++ b/t/chown.t
@@ -7,7 +7,7 @@ use Test2::Bundle::Extended;
 use Test2::Tools::Explain;
 use Test2::Plugin::NoWarnings;
 use Test2::Tools::Exception qw< lives dies >;
-use Test::MockFile qw< strict >;
+use Test::MockFile ();
 
 my $euid     = $>;
 my $egid     = int $);

--- a/t/detect-common-mistakes.t
+++ b/t/detect-common-mistakes.t
@@ -7,7 +7,7 @@ use Test2::Bundle::Extended;
 use Test2::Tools::Explain;
 use Test2::Plugin::NoWarnings;
 use Test2::Tools::Exception qw< lives dies >;
-use Test::MockFile qw< strict >;
+use Test::MockFile;
 
 subtest(
     'Removing trailing forward slash for directories' => sub {

--- a/t/dir_interface.t
+++ b/t/dir_interface.t
@@ -7,7 +7,7 @@ use Test2::Bundle::Extended;
 use Test2::Tools::Explain;
 use Test2::Plugin::NoWarnings;
 use Test2::Tools::Exception qw< lives dies >;
-use Test::MockFile qw< strict >;
+use Test::MockFile;
 
 sub test_content_with_keywords {
     my ( $dirname, $dir_content ) = @_;

--- a/t/file_access_hooks.t
+++ b/t/file_access_hooks.t
@@ -13,7 +13,7 @@ use Fcntl;
 
 #use Errno qw/ENOENT EBADF/;
 
-use Test::MockFile qw/strict/;    # Everything below this can have its open overridden.
+use Test::MockFile;    # Everything below this can have its open overridden.
 my ( undef, $temp_file ) = tempfile();
 my $temp_dir = tempdir( CLEANUP => 1 );
 

--- a/t/file_from_disk.t
+++ b/t/file_from_disk.t
@@ -8,7 +8,7 @@ use Test::More;
 use File::Temp qw/tempfile/;
 use File::Slurper ();
 
-use Test::MockFile;    # Everything below this can have its open overridden.
+use Test::MockFile qw< nostrict >;    # Everything below this can have its open overridden.
 
 my $fake_file_contents = "abc\n" . ( "x" x 20 ) . "\n";
 

--- a/t/globbing.t
+++ b/t/globbing.t
@@ -4,7 +4,7 @@ use warnings;
 use Test2::Bundle::Extended;
 use Test2::Tools::Explain;
 use Test2::Plugin::NoWarnings;
-use Test::MockFile qw< strict >;
+use Test::MockFile;
 
 my $file1 = Test::MockFile->file('/file1.txt');
 my $file2 = Test::MockFile->file('/file2.txt');

--- a/t/goto_is_available.t
+++ b/t/goto_is_available.t
@@ -7,7 +7,7 @@ use Test2::Bundle::Extended;
 use Test2::Tools::Explain;
 use Test2::Plugin::NoWarnings;
 
-use Test::MockFile ();
+use Test::MockFile qw< nostrict >;
 
 Internals::SvREADONLY( $], 0 );
 

--- a/t/handle-corruption.t
+++ b/t/handle-corruption.t
@@ -7,7 +7,7 @@ use Test2::Bundle::Extended;
 use Test2::Tools::Explain;
 use Test2::Tools::Exception qw< lives >;
 use Test2::Plugin::NoWarnings;
-use Test::MockFile qw< strict >;
+use Test::MockFile;
 use IO::Handle;
 
 my $handle = IO::Handle->new();

--- a/t/mkdir.t
+++ b/t/mkdir.t
@@ -13,7 +13,7 @@ use File::Temp qw/tempfile tempdir/;
 my $temp_dir_name = tempdir( CLEANUP => 1 );
 CORE::rmdir $temp_dir_name;
 
-use Test::MockFile ();
+use Test::MockFile qw< nostrict >;
 
 # Proves umask works in this test.
 umask 022;

--- a/t/mock_stat.t
+++ b/t/mock_stat.t
@@ -7,7 +7,7 @@ use Test2::Bundle::Extended;
 use Test2::Tools::Explain;
 use Test2::Plugin::NoWarnings;
 
-use Test::MockFile ();
+use Test::MockFile qw< nostrict >;
 use Overload::FileCheck qw/:check/;
 use Errno qw/ELOOP/;
 

--- a/t/open-noclose.t
+++ b/t/open-noclose.t
@@ -7,7 +7,7 @@ use Test2::Bundle::Extended;
 use Test2::Tools::Explain;
 use Test2::Plugin::NoWarnings;
 
-use Test::MockFile;
+use Test::MockFile qw< nostrict >;
 
 {
     like(

--- a/t/open.t
+++ b/t/open.t
@@ -8,7 +8,7 @@ use Errno qw/ENOENT/;
 
 use File::Temp qw/tempfile/;
 
-use Test::MockFile;    # Everything below this can have its open overridden.
+use Test::MockFile qw< nostrict >;    # Everything below this can have its open overridden.
 
 my $test_string = "abcd\nefgh\n";
 my ( $fh_real, $filename ) = tempfile();

--- a/t/opendir.t
+++ b/t/opendir.t
@@ -12,7 +12,7 @@ use File::Basename;
 
 use Errno qw/ENOENT EBADF ENOTDIR/;
 
-use Test::MockFile;    # Everything below this can have its open overridden.
+use Test::MockFile qw< nostrict >;    # Everything below this can have its open overridden.
 
 my $temp_dir = tempdir( CLEANUP => 1 );
 my ( undef, $filename )    = tempfile( DIR => $temp_dir );

--- a/t/path.t
+++ b/t/path.t
@@ -7,7 +7,7 @@ use Test2::Bundle::Extended;
 use Test2::Tools::Explain;
 use Test2::Plugin::NoWarnings;
 
-use Test::MockFile ();
+use Test::MockFile qw< nostrict >;
 
 my $path = '/some/nonexistant/path';
 my $mock = Test::MockFile->file($path);

--- a/t/readline.t
+++ b/t/readline.t
@@ -11,7 +11,7 @@ use Errno qw/ENOENT EBADF/;
 
 use File::Temp qw/tempfile/;
 
-use Test::MockFile;    # Everything below this can have its open overridden.
+use Test::MockFile qw< nostrict >;    # Everything below this can have its open overridden.
 
 my ( $fh_real, $filename ) = tempfile();
 print {$fh_real} "not\nmocked\n";

--- a/t/readlink.t
+++ b/t/readlink.t
@@ -22,7 +22,7 @@ my $bad_symlink = "$temp_dir_name/c";
 CORE::symlink( "a",        $symlink );
 CORE::symlink( "notafile", $bad_symlink );
 
-use Test::MockFile ();
+use Test::MockFile qw< nostrict >;
 
 note "-------------- REAL MODE --------------";
 $! = 0;

--- a/t/rmdir.t
+++ b/t/rmdir.t
@@ -13,7 +13,7 @@ use File::Temp qw/tempfile tempdir/;
 my $temp_dir_name = tempdir( CLEANUP => 1 );
 CORE::rmdir $temp_dir_name;
 
-use Test::MockFile ();
+use Test::MockFile qw< nostrict >;
 
 # Proves umask works in this test.
 umask 022;

--- a/t/runtime-bareword-filehandles.t
+++ b/t/runtime-bareword-filehandles.t
@@ -7,7 +7,7 @@ use Test2::Plugin::NoWarnings;
 use Test2::Tools::Exception qw< lives >;
 
 # This must be loaded after other modules that use open() in BEGIN
-use Test::MockFile ();    # specifically not "strict" to trigger the issue
+use Test::MockFile qw< nostrict >;    # specifically not "strict" to trigger the issue
 
 # This must be loaded after Test::MockFile so we override the core functions
 # that will be used in File::Find when it compiles

--- a/t/stat-x.t
+++ b/t/stat-x.t
@@ -6,7 +6,7 @@ use warnings;
 use Test2::Bundle::Extended;
 use Test2::Tools::Explain;
 use Test2::Plugin::NoWarnings;
-use Test::MockFile qw< strict >;
+use Test::MockFile;
 
 subtest(
     '-x after unlink' => sub {

--- a/t/symlink.t
+++ b/t/symlink.t
@@ -7,7 +7,7 @@ use Test2::Bundle::Extended;
 use Test2::Tools::Explain;
 use Test2::Plugin::NoWarnings;
 use Test2::Tools::Exception qw< lives dies >;
-use Test::MockFile qw< strict >;
+use Test::MockFile;
 
 my $dir  = Test::MockFile->dir('/foo');
 my $file = Test::MockFile->file('/bar');

--- a/t/sysopen.t
+++ b/t/sysopen.t
@@ -14,7 +14,7 @@ use Fcntl;
 
 #use Errno qw/ENOENT EBADF/;
 
-use Test::MockFile;    # Everything below this can have its open overridden.
+use Test::MockFile qw< nostrict >;    # Everything below this can have its open overridden.
 my ( undef, $filename ) = tempfile();
 unlink $filename;
 

--- a/t/touch.t
+++ b/t/touch.t
@@ -22,7 +22,7 @@ SKIP: {
     ok( $unlink_dir_errorno, "unlink /dir is non-zero ($unlink_dir_errorno)" );
 }
 
-use Test::MockFile ();
+use Test::MockFile qw< nostrict >;
 
 note "-------------- MOCK MODE --------------";
 my @mock;

--- a/t/unlink.t
+++ b/t/unlink.t
@@ -19,7 +19,7 @@ my ( $fh, $existing_file_name ) = tempfile();
 print $fh "This is the real file\n";
 close $fh;
 
-use Test::MockFile ();
+use Test::MockFile qw< nostrict >;
 
 subtest 'unlink on a missing file' => sub {
     $! = 0;

--- a/t/writeline.t
+++ b/t/writeline.t
@@ -9,7 +9,7 @@ use Test2::Plugin::NoWarnings;
 
 use File::Temp qw/tempfile/;
 
-use Test::MockFile;    # Everything below this can have its open overridden.
+use Test::MockFile qw<nostrict>;    # Everything below this can have its open overridden.
 
 note "-------------- REAL MODE --------------";
 my ( $fh_real, $filename ) = tempfile();


### PR DESCRIPTION

    use Test::MockFile;                # strict mode
    use Test::MockFile ();             # still strict mode
    use Test::MockFile qw< nostrict >; # non-strict mode

Resolves GH #75.