### PR TITLE
Support two-arg open, read/write, and understand pipes

### DIFF
--- a/t/open.t
+++ b/t/open.t
@@ -57,5 +57,100 @@ my $mock_link = Test::MockFile->symlink( $filename, '/qwerty' );
     is( $! + 0,                         ENOENT, '$! is ENOENT' );
 }
 
+subtest(
+    'open modes' => sub {
+        foreach my $write_mode (qw( > >> )) {
+            my $open_str = $write_mode . '/debug.log';
+            my $file     = Test::MockFile->file( '/debug.log', '' );
+            my $fh;
+
+            $! = 0;
+            ok( open( $fh, $open_str ), "Two-arg $write_mode open works" );
+            is( $! + 0, 0, 'No error' );
+
+            $! = 0;
+            ok( close($fh), 'Successfully closed open handle' );
+            is( $! + 0, 0, 'No error' );
+        }
+
+        foreach my $read_mode ( '<', '' ) {
+            my $open_str = $read_mode . '/debug.log';
+            my $file     = Test::MockFile->file( '/debug.log', '' );
+            my $fh;
+
+            $! = 0;
+            ok( open( $fh, $open_str ), "Two-arg $read_mode open works" );
+            is( $open_str, "${read_mode}/debug.log", "arg not changed" );
+            is( $! + 0,    0,                        'No error' );
+
+            $! = 0;
+            ok( close($fh), 'Successfully closed open handle' );
+            is( $! + 0, 0, 'No error' );
+        }
+
+        foreach my $multi_mode (qw( +< +> )) {
+            my $open_str = $multi_mode . '/debug.log';
+            my $file     = Test::MockFile->file( '/debug.log', '' );
+            my $fh;
+
+            $! = 0;
+            ok( open( $fh, $open_str ), "Two-arg $multi_mode open fails" );
+            is( $! + 0, 0, 'No error' );
+
+            $! = 0;
+            ok( open( $fh, $multi_mode, '/debug.log' ), "Three-arg $multi_mode open fails" );
+            is( $! + 0, 0, 'No error' );
+        }
+
+        # Pipe open pass-through
+        my ( $fh, $tempfile ) = tempfile( 'CLEANUP' => 1 );
+        my $pipefh;
+
+        # Three-arg pipe write
+        ok( open( $pipefh, '|-', "echo hello >> $tempfile" ), 'Succesful three-arg pipe open write' );
+
+        # No point testing $! because it will correctly be set to ESPIPE (29, illegal seek)
+
+        $! = 0;
+        ok( close($pipefh), 'Successfully closed pipe' );
+        is( $! + 0, 0, 'No error' );
+
+        # Two-arg pipe write
+        ok( open( $pipefh, "|echo world >> $tempfile" ), 'Succesful two-arg pipe open write' );
+
+        # No point testing $! because it will correctly be set to ESPIPE (29, illegal seek)
+
+        $! = 0;
+        ok( close($pipefh), 'Successfully closed pipe' );
+        is( $! + 0, 0, 'No error' );
+
+        # Three-arg pipe write
+        ok( open( $pipefh, '-|', "cat $tempfile" ), 'Succesful three-arg pipe open read' );
+
+        # No point testing $! because it will correctly be set to ESPIPE (29, illegal seek)
+
+        my $out = <$pipefh>;
+        is( $out, "hello\n", 'Succesfully read from pipe with three-arg' );
+
+        ok( close($pipefh), 'Successfully closed pipe' );
+
+        # No point testing $! because it will correctly be set to ESPIPE (29, illegal seek)
+
+        # Two-arg pipe write
+        $out = '';
+        ok( open( $pipefh, "cat $tempfile|" ), 'Succesful two-arg pipe open read' );
+
+        # No point testing $! because it will correctly be set to ESPIPE (29, illegal seek)
+
+        $out = <$pipefh>;
+        $out .= <$pipefh>;
+        is( $out, "hello\nworld\n", 'Succesfully read from pipe with two-arg' );
+
+        $! = 0;
+        ok( close($pipefh), 'Successfully closed pipe' );
+        is( $! + 0, 0, 'No error' );
+    }
+);
+
 done_testing();
 exit;


### PR DESCRIPTION
* We now support two-arg `open()`:

```perl
    open $fh, '>foo'
    open $fh, '>>foo'
    open $fh, '<foo'
    open $fh, 'foo'
```

* We now understand pipes but pass them through to CORE:

```perl
    open $fh, '|-', 'foo'
    open $fh, '-|', 'foo'
    open $fh, '|foo'
    open $fh, 'foo|'
```

Resolves GH #122.