### PR TITLE
Add strict guards for additional keywords

### DIFF
--- a/lib/Test/MockFile.pm
+++ b/lib/Test/MockFile.pm
@@ -1549,6 +1549,7 @@ BEGIN {
         my $mocked_dir = _get_file_object( $_[0] );
 
         if ( !$mocked_dir ) {
+            _real_file_access_hook( 'readdir', [ \@_ ] );
             goto \&CORE::readdir if _goto_is_available();
             return CORE::readdir( $_[0] );
         }
@@ -1590,6 +1591,7 @@ BEGIN {
         my $mocked_dir = _get_file_object($fh);
 
         if ( !$mocked_dir || !$mocked_dir->{'obj'} ) {
+            _real_file_access_hook( 'telldir', [ \@_ ] );
             goto \&CORE::telldir if _goto_is_available();
             return CORE::telldir($fh);
         }
@@ -1616,6 +1618,7 @@ BEGIN {
         my $mocked_dir = _get_file_object($fh);
 
         if ( !$mocked_dir || !$mocked_dir->{'obj'} ) {
+            _real_file_access_hook( 'rewinddir', [ \@_ ] );
             goto \&CORE::rewinddir if _goto_is_available();
             return CORE::rewinddir( $_[0] );
         }
@@ -1643,6 +1646,7 @@ BEGIN {
         my $mocked_dir = _get_file_object($fh);
 
         if ( !$mocked_dir || !$mocked_dir->{'obj'} ) {
+            _real_file_access_hook( 'seekdir', [ \@_ ] );
             goto \&CORE::seekdir if _goto_is_available();
             return CORE::seekdir( $fh, $goto );
         }
@@ -1669,6 +1673,7 @@ BEGIN {
         my $mocked_dir = _get_file_object($fh);
 
         if ( !$mocked_dir || !$mocked_dir->{'obj'} ) {
+            _real_file_access_hook( 'closedir', [ \@_ ] );
             goto \&CORE::closedir if _goto_is_available();
             return CORE::closedir($fh);
         }
@@ -1715,6 +1720,7 @@ BEGIN {
 
         my $mock_object = _get_file_object($file);
         if ( !$mock_object ) {
+            _real_file_access_hook( 'readlink', [ \@_ ] );
             goto \&CORE::readlink if _goto_is_available();
             return CORE::readlink($file);
         }
@@ -1743,8 +1749,8 @@ BEGIN {
         my $mock = _get_file_object($file);
 
         if ( !$mock ) {
+            _real_file_access_hook( 'mkdir', [ \@_ ] );
             goto \&CORE::mkdir if _goto_is_available();
-
             return CORE::mkdir(@_);
         }
 
@@ -1779,6 +1785,7 @@ BEGIN {
         my $mock = _get_file_object($file);
 
         if ( !$mock ) {
+            _real_file_access_hook( 'rmdir', [ \@_ ] );
             goto \&CORE::rmdir if _goto_is_available();
             return CORE::rmdir($file);
         }


### PR DESCRIPTION
* `readdir`
* `telldir`
* `rewinddir`
* `seekdir`
* `closedir`
* `readlink`
* `mkdir`
* `rmdir`

Resolves #81.