### PR TITLE
Provide a mechanism to setup custom strict rules

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -35,6 +35,8 @@ t/readlink.t
 t/rmdir.t
 t/runtime-bareword-filehandles.t
 t/stat-x.t
+t/strict-rules.t
+t/strict-rules_file-temp-example.t
 t/symlink.t
 t/sysopen.t
 t/Test-MockFile_file.t

--- a/lib/Test/MockFile.pm
+++ b/lib/Test/MockFile.pm
@@ -270,7 +270,7 @@ sub file_arg_position_for_command {    # can also be used by user hooks
         'unlink'   => 0,
     };
 
-    croak("Unknown strict mode violation for $command") unless defined $command && defined $_file_arg_post->{$command};
+    return -1 unless defined $command && defined $_file_arg_post->{$command};
 
     # exception for open
     return 1 if $command eq 'open' && ref $at_under_ref && scalar @$at_under_ref == 2;
@@ -289,7 +289,7 @@ sub _get_stack {
         last if !defined $stack[0];    # We don't know when this would ever happen.
 
         next if $stack[0] eq __PACKAGE__;
-        next if $stack[0] eq 'Overload::FileCheck';
+        next if $stack[0] eq 'Overload::FileCheck';    # companion package
 
         return if $authorized_strict_mode_packages{ $stack[0] };
 
@@ -297,6 +297,165 @@ sub _get_stack {
     }
 
     return @stack;
+}
+
+=head2 add_strict_rule( $command_rule, $file_rule, $action )
+
+Args: ($command_rule, $file_rule, $action)
+
+Add a custom rule to validate strictness mode.
+This is the fundation to add strict rules.
+You should use it, when none of the other helper to add rules work
+for you.
+
+=over
+
+=item C<$command_rule> a string, or regexp or list of any to indicate
+which command to match
+
+=itemC<$file_rule> a string, or regexp or list of any to indicate
+which files your rules apply to.
+
+=item C<$action> a CODE ref or scalar to handle the exception.
+Returning '1' skip all other rules and indicate an exception.
+
+=back
+
+    add_strict_rule( 'open', '/this/file', sub { ... } );
+
+    add_strict_rule( 'open', '/this/file', 1 ); # always bypass the strict rule
+
+    add_strict_rule( 'open', '/this/file', sub {
+        my ( $context ) = @_;
+
+        return; # continue and check the next rule
+
+        return 1; # this is an exception, and I know this is not strict - abort all other rules
+    } );
+
+=cut
+
+my @STRICT_RULES;
+
+sub add_strict_rule {
+    my ( $command_rule, $file_rule, $action ) = @_;
+
+    my $rule = {};    # could use a package name for this
+    $rule->{command_rule} = $command_rule if defined $command_rule;
+    $rule->{file_rule}    = $file_rule    if defined $file_rule;
+
+    croak("Invalid rule: missing action code") unless defined $action;
+
+    #croak( "Invalid rule: missing action code" ) unless ref $action eq 'CODE';
+
+    $rule->{action} = $action;
+
+    push @STRICT_RULES, $rule;
+
+    return;
+}
+
+=head2 clear_srtrict_rules()
+
+Args: none
+
+Clear all previously defined rules.
+(Mainly used for testing purpose)
+
+=cut
+
+sub clear_srtrict_rules {
+    @STRICT_RULES = ();
+
+    return;
+}
+
+=head2 add_strict_rule_for_filename( $file_rule, $action )
+
+Args: ($file_rule, $action)
+
+Prefer using that helper when trying to add strict rules targeting files.
+
+Apply a rule to one or more files.
+
+    add_strict_rule_for_filename( '/that/file' => sub { ... } );
+
+    add_strict_rule_for_filename( [ qw{list of files} ] => sub { ... } );
+
+    add_strict_rule_for_filename( qr{*\.t$} => sub { ... } );
+
+    add_strict_rule_for_filename( [ $dir, qr{^${dir}/} ] => 1 );
+
+=cut
+
+sub add_strict_rule_for_filename {
+    my ( $file_rule, $action ) = @_;
+
+    return add_strict_rule( undef, $file_rule, $action );
+}
+
+=head2 add_strict_rule_for_command( $command_rule, $action )
+
+Args: ($command_rule, $action)
+
+Prefer using that helper when trying to add strict rules targeting specici commands.
+
+Apply a rule to one or more files.
+
+    add_strict_rule_for_command( 'open' => sub { ... } );
+
+    add_strict_rule_for_command( [ qw{open readdir} ] => sub { ... } );
+
+    add_strict_rule_for_command( qr{open.*} => sub { ... } );
+
+    Test::MockFile::add_strict_rule_for_command(
+        [qw{ readdir closedir readlink }],
+        sub {
+            my ($ctx) = @_;
+            my $command = $ctx->{command} // 'unknown';
+
+            warn( "Ignoring strict mode violation for $command" );
+            return 1;
+        }
+    );
+
+=cut
+
+sub add_strict_rule_for_command {
+    my ( $command_rule, $action ) = @_;
+
+    return add_strict_rule( $command_rule, undef, $action );
+}
+
+=head2 add_strict_rule_generic( $action )
+
+Args: ($action)
+
+Prefer using that helper when adding a rule which is global
+and does not apply to a specific command or file.
+
+Apply a rule to one or more files.
+
+    add_strict_rule_generic( sub { ... } );
+
+    add_strict_rule_generic( sub  {
+        my ($ctx) = @_;
+
+        my $filename = $ctx->{filename};
+
+        return unless defined $filename;
+
+        return 1 if UNIVERSAL::isa( $filename, 'GLOB' );
+
+        return;
+    } );
+
+=cut
+
+sub add_strict_rule_generic {
+    my ($action) = @_;
+
+    return add_strict_rule( undef, undef, $action );
 }
 
 sub _strict_mode_violation {
@@ -307,15 +466,72 @@ sub _strict_mode_violation {
     my @stack = _get_stack();
     return unless scalar @stack;    # skip the package
 
+    my $filename;
+
     # check it later so we give priority to authorized_strict_mode_packages
     my $file_arg = file_arg_position_for_command( $command, $at_under_ref );
 
-    my $filename = scalar @$at_under_ref <= $file_arg ? '<not specified>' : $at_under_ref->[$file_arg];
+    if ( $file_arg >= 0 ) {
+        $filename = scalar @$at_under_ref <= $file_arg ? '<not specified>' : $at_under_ref->[$file_arg];
+    }
 
     # Ignore stats on STDIN, STDOUT, STDERR
-    return if $filename =~ m/^\*?(?:main::)?[<*&+>]*STD(?:OUT|IN|ERR)$/;
+    return if defined $filename && $filename =~ m/^\*?(?:main::)?[<*&+>]*STD(?:OUT|IN|ERR)$/;
+
+    my $path = _abs_path_to_file($filename);
+
+    my $context = {
+        command      => $command,
+        filename     => $path,
+        at_under_ref => $at_under_ref
+    };    # object
+
+    return if _dispatch_strict_rules($context);
+
+    croak("Unknown strict mode violation for $command") if $file_arg == -1;
 
     confess("Use of $command to access unmocked file or directory '$filename' in strict mode at $stack[1] line $stack[2]");
+}
+
+sub _dispatch_strict_rules {
+    my ($context) = @_;
+
+    # rules dispatch
+    foreach my $rule (@STRICT_RULES) {
+
+        # validate file_rule
+        next unless _check_rule_condition->( $context->{filename}, $rule->{file_rule} );
+
+        # validate command_rule
+        next unless _check_rule_condition->( $context->{command}, $rule->{command_rule} );
+
+        my $answer = ref $rule->{action} ? $rule->{action}->($context) : $rule->{action};
+
+        # for now the only known answer to the rules, otherwise keep going
+        return 1 if $answer && $answer == 1;
+    }
+
+    return;
+}
+
+sub _check_rule_condition {
+    my ( $str, $match ) = @_;
+
+    return 1 unless defined $match;    # no restrictions
+    return   unless defined $str;      #
+
+    if ( my $isa = ref $match ) {
+        return 1 if $isa eq 'Regexp' && $str =~ $match;
+        if ( $isa eq 'ARRAY' ) {
+            foreach my $m (@$match) {
+                return 1 if _check_rule_condition( $str, $m );
+            }
+        }
+    }
+
+    return 1 if $str eq $match;
+
+    return;
 }
 
 sub import {
@@ -812,7 +1028,7 @@ sub _files_in_dir {
 sub _abs_path_to_file {
     my ($path) = shift;
 
-    defined $path or return;
+    return unless defined $path;
 
     my $match = 1;
     while ($match) {

--- a/t/strict-rules.t
+++ b/t/strict-rules.t
@@ -1,0 +1,103 @@
+#!/usr/bin/perl -w
+
+use strict;
+use warnings;
+
+use Test2::Bundle::Extended;
+use Test2::Tools::Explain;
+use Test2::Plugin::NoWarnings;
+
+use Test::MockFile qw< strict >;    # yeap it's strict
+
+like dies { open( my $fh, ">", '/this/is/a/test' ) }, qr{Use of open to access unmocked file or directory},
+  "Cannot open an unmocked file in strict mode";
+
+note "add_strict_rule_for_filename";
+
+Test::MockFile::add_strict_rule_for_filename( "/cherry" => 1 );
+ok lives { open( my $fh, '>', '/cherry' ) },     "can open a file with a custom rule";
+ok dies { open( my $fh, '>', '/cherry/abcd' ) }, "cannot open a file under the directory";
+
+Test::MockFile::add_strict_rule_for_filename( "/another" => 1 );
+foreach my $f (qw{/cherry /another}) {
+    ok lives { open( my $fh, '>', $f ) }, "open $f with multiple rules";
+}
+
+Test::MockFile::clear_srtrict_rules();
+ok dies { open( my $fh, '>', '/cherry' ) }, "clear_srtrict_rules removes all previous rules";
+
+Test::MockFile::add_strict_rule_for_filename( qr{^/cherry} => 1 );
+ok lives { open( my $fh, '>', '/cherry' ) },      "can open a file with a custom rule - regexp";
+ok lives { open( my $fh, '>', '/cherry/abcd' ) }, "can open a file with a custom rule - regexp";
+
+Test::MockFile::clear_srtrict_rules();
+
+Test::MockFile::add_strict_rule_for_filename( [ qw{/foo /bar}, qr{^/cherry} ] => 1 );
+ok lives { open( my $fh, '>', '/foo' ) },         "add_strict_rule_for_filename multiple rules";
+ok lives { open( my $fh, '>', '/cherry/abcd' ) }, "add_strict_rule_for_filename multiple rules";
+
+Test::MockFile::clear_srtrict_rules();
+
+note "add_strict_rule_for_command";
+
+ok dies { opendir( my $fh, '/whatever' ) }, "opendir fails without add_strict_rule_for_command";
+
+Test::MockFile::add_strict_rule_for_command( 'opendir' => 1 );
+
+ok lives { opendir( my $fh, '/whatever' ) }, "add_strict_rule_for_command";
+
+Test::MockFile::clear_srtrict_rules();
+
+Test::MockFile::add_strict_rule_for_command( qr{op.*} => 1 );
+
+ok lives { opendir( my $fh, '/whatever' ) }, "add_strict_rule_for_command - regexp";
+Test::MockFile::clear_srtrict_rules();
+
+Test::MockFile::add_strict_rule_for_command( [ 'abcd', 'opendir' ] => 1 );
+
+ok lives { opendir( my $fh, '/whatever' ) }, "add_strict_rule_for_command - list";
+Test::MockFile::clear_srtrict_rules();
+
+note "add_strict_rule_generic";
+
+ok dies { open( my $fh, '>', '/cherry' ) }, "no rules setup";
+
+my $context;
+Test::MockFile::add_strict_rule_generic(
+    sub {
+        my ($ctx) = @_;
+
+        $context = $ctx;
+
+        return 1;
+    }
+);
+
+ok lives { open( my $fh, '>', '/cherry' ) }, "add_strict_rule_generic";
+
+if ( $^V >= 5.18.0 ) {    # behaving differently in 5.16 due to glob stuff...
+    is $context, {
+        'at_under_ref' => [
+            D(),
+            '>',
+            '/cherry'
+        ],
+        'command'  => 'open',
+        'filename' => '/cherry'
+      },
+      "context set for open" or diag explain $context;
+
+}
+
+ok lives { open( my $fh, '>', '/////cherry' ) }, "add_strict_rule_generic";
+is $context->{filename}, '/cherry', "context uses normalized path";
+
+my $is_exception;
+Test::MockFile::clear_srtrict_rules();
+Test::MockFile::add_strict_rule_generic( sub { $is_exception } );
+
+ok dies { open( my $fh, '>', '/cherry' ) }, "add_strict_rule_generic - no exception";
+$is_exception = 1;
+ok lives { open( my $fh, '>', '/cherry' ) }, "add_strict_rule_generic - exception";
+
+done_testing;

--- a/t/strict-rules_file-temp-example.t
+++ b/t/strict-rules_file-temp-example.t
@@ -1,0 +1,79 @@
+#!/usr/bin/perl -w
+
+use strict;
+use warnings;
+
+use Test2::Bundle::Extended;
+use Test2::Tools::Explain;
+use Test2::Plugin::NoWarnings;
+
+use File::Temp ();    # not loaded under strict mode...
+
+use Test::MockFile qw< strict >;    # yeap it's strict
+
+{
+    ###
+    ### Without mock
+    ###
+    my ( $tmp_fh, $tmp ) = File::Temp::tempfile;
+
+    like dies { open( my $fh, ">", "$tmp" ) }, qr{Use of open to access unmocked file or directory},
+      "Cannot open an unmocked file in strict mode";
+
+    my $tempdir = File::Temp::tempdir( CLEANUP => 1 );
+    like dies { opendir( my $dh, "$tempdir" ) }, qr{Use of opendir to access unmocked}, "Cannot open directory from tempdir";
+
+}
+
+{
+
+    ##
+    ## After mock
+    ##
+
+    ok _setup_strict_rules_for_file_temp(), "_setup_strict_rules_for_file_temp";
+
+    my ( $tmp_fh, $tmp ) = File::Temp::tempfile;
+
+    ok lives { open( my $fh, ">", "$tmp" ) }, "we can open a tempfile";
+
+    my $tempdir = File::Temp::tempdir( CLEANUP => 1 );
+    ok lives { opendir( my $dh, "$tempdir" ) }, "Can open directory from tempdir";
+
+}
+
+done_testing;
+
+sub _setup_strict_rules_for_file_temp {
+
+    no warnings qw{redefine once};
+
+    {
+        my $sub_tempfile = File::Temp->can('tempfile');
+        *File::Temp::tempfile = sub {
+            my (@in) = @_;
+
+            my @out = $sub_tempfile->(@in);
+
+            Test::MockFile::add_strict_rule_for_filename( $out[1] => 1 );
+
+            return @out;
+        };
+    }
+
+    {
+        my $sub_tempdir = File::Temp->can('tempdir');
+        *File::Temp::tempdir = sub {
+            my (@in) = @_;
+
+            my $out = $sub_tempdir->(@in);
+            my $dir = "$out";
+
+            Test::MockFile::add_strict_rule_for_filename( [ $dir, qr{^${dir}/} ] => 1 );
+
+            return $out;
+        };
+    }
+
+    return 1;
+}


### PR DESCRIPTION
This commit introduces a few helpers:
    - add_strict_rule
    - add_strict_rule_for_filename
    - add_strict_rule_for_command
    - add_strict_rule_generic
to add custom rules to enhance the strict mode
by authorizing some exceptions.