### PR TITLE
Provide a mechanism to setup custom strict rules

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -35,6 +35,8 @@ t/readlink.t
 t/rmdir.t
 t/runtime-bareword-filehandles.t
 t/stat-x.t
+t/strict-rules.t
+t/strict-rules_file-temp-example.t
 t/symlink.t
 t/sysopen.t
 t/Test-MockFile_file.t

--- a/t/strict-rules.t
+++ b/t/strict-rules.t
@@ -1,0 +1,103 @@
+#!/usr/bin/perl -w
+
+use strict;
+use warnings;
+
+use Test2::Bundle::Extended;
+use Test2::Tools::Explain;
+use Test2::Plugin::NoWarnings;
+
+use Test::MockFile qw< strict >;    # yeap it's strict
+
+like dies { open( my $fh, ">", '/this/is/a/test' ) }, qr{Use of open to access unmocked file or directory},
+  "Cannot open an unmocked file in strict mode";
+
+note "add_strict_rule_for_filename";
+
+Test::MockFile::add_strict_rule_for_filename( "/cherry" => 1 );
+ok lives { open( my $fh, '>', '/cherry' ) },     "can open a file with a custom rule";
+ok dies { open( my $fh, '>', '/cherry/abcd' ) }, "cannot open a file under the directory";
+
+Test::MockFile::add_strict_rule_for_filename( "/another" => 1 );
+foreach my $f (qw{/cherry /another}) {
+    ok lives { open( my $fh, '>', $f ) }, "open $f with multiple rules";
+}
+
+Test::MockFile::clear_srtrict_rules();
+ok dies { open( my $fh, '>', '/cherry' ) }, "clear_srtrict_rules removes all previous rules";
+
+Test::MockFile::add_strict_rule_for_filename( qr{^/cherry} => 1 );
+ok lives { open( my $fh, '>', '/cherry' ) },      "can open a file with a custom rule - regexp";
+ok lives { open( my $fh, '>', '/cherry/abcd' ) }, "can open a file with a custom rule - regexp";
+
+Test::MockFile::clear_srtrict_rules();
+
+Test::MockFile::add_strict_rule_for_filename( [ qw{/foo /bar}, qr{^/cherry} ] => 1 );
+ok lives { open( my $fh, '>', '/foo' ) },         "add_strict_rule_for_filename multiple rules";
+ok lives { open( my $fh, '>', '/cherry/abcd' ) }, "add_strict_rule_for_filename multiple rules";
+
+Test::MockFile::clear_srtrict_rules();
+
+note "add_strict_rule_for_command";
+
+ok dies { opendir( my $fh, '/whatever' ) }, "opendir fails without add_strict_rule_for_command";
+
+Test::MockFile::add_strict_rule_for_command( 'opendir' => 1 );
+
+ok lives { opendir( my $fh, '/whatever' ) }, "add_strict_rule_for_command";
+
+Test::MockFile::clear_srtrict_rules();
+
+Test::MockFile::add_strict_rule_for_command( qr{op.*} => 1 );
+
+ok lives { opendir( my $fh, '/whatever' ) }, "add_strict_rule_for_command - regexp";
+Test::MockFile::clear_srtrict_rules();
+
+Test::MockFile::add_strict_rule_for_command( [ 'abcd', 'opendir' ] => 1 );
+
+ok lives { opendir( my $fh, '/whatever' ) }, "add_strict_rule_for_command - list";
+Test::MockFile::clear_srtrict_rules();
+
+note "add_strict_rule_generic";
+
+ok dies { open( my $fh, '>', '/cherry' ) }, "no rules setup";
+
+my $context;
+Test::MockFile::add_strict_rule_generic(
+    sub {
+        my ($ctx) = @_;
+
+        $context = $ctx;
+
+        return 1;
+    }
+);
+
+ok lives { open( my $fh, '>', '/cherry' ) }, "add_strict_rule_generic";
+
+if ( $^V >= 5.18.0 ) {    # behaving differently in 5.16 due to glob stuff...
+    is $context, {
+        'at_under_ref' => [
+            D(),
+            '>',
+            '/cherry'
+        ],
+        'command'  => 'open',
+        'filename' => '/cherry'
+      },
+      "context set for open" or diag explain $context;
+
+}
+
+ok lives { open( my $fh, '>', '/////cherry' ) }, "add_strict_rule_generic";
+is $context->{filename}, '/cherry', "context uses normalized path";
+
+my $is_exception;
+Test::MockFile::clear_srtrict_rules();
+Test::MockFile::add_strict_rule_generic( sub { $is_exception } );
+
+ok dies { open( my $fh, '>', '/cherry' ) }, "add_strict_rule_generic - no exception";
+$is_exception = 1;
+ok lives { open( my $fh, '>', '/cherry' ) }, "add_strict_rule_generic - exception";
+
+done_testing;

--- a/t/strict-rules_file-temp-example.t
+++ b/t/strict-rules_file-temp-example.t
@@ -1,0 +1,79 @@
+#!/usr/bin/perl -w
+
+use strict;
+use warnings;
+
+use Test2::Bundle::Extended;
+use Test2::Tools::Explain;
+use Test2::Plugin::NoWarnings;
+
+use File::Temp ();    # not loaded under strict mode...
+
+use Test::MockFile qw< strict >;    # yeap it's strict
+
+{
+    ###
+    ### Without mock
+    ###
+    my ( $tmp_fh, $tmp ) = File::Temp::tempfile;
+
+    like dies { open( my $fh, ">", "$tmp" ) }, qr{Use of open to access unmocked file or directory},
+      "Cannot open an unmocked file in strict mode";
+
+    my $tempdir = File::Temp::tempdir( CLEANUP => 1 );
+    like dies { opendir( my $dh, "$tempdir" ) }, qr{Use of opendir to access unmocked}, "Cannot open directory from tempdir";
+
+}
+
+{
+
+    ##
+    ## After mock
+    ##
+
+    ok _setup_strict_rules_for_file_temp(), "_setup_strict_rules_for_file_temp";
+
+    my ( $tmp_fh, $tmp ) = File::Temp::tempfile;
+
+    ok lives { open( my $fh, ">", "$tmp" ) }, "we can open a tempfile";
+
+    my $tempdir = File::Temp::tempdir( CLEANUP => 1 );
+    ok lives { opendir( my $dh, "$tempdir" ) }, "Can open directory from tempdir";
+
+}
+
+done_testing;
+
+sub _setup_strict_rules_for_file_temp {
+
+    no warnings qw{redefine once};
+
+    {
+        my $sub_tempfile = File::Temp->can('tempfile');
+        *File::Temp::tempfile = sub {
+            my (@in) = @_;
+
+            my @out = $sub_tempfile->(@in);
+
+            Test::MockFile::add_strict_rule_for_filename( $out[1] => 1 );
+
+            return @out;
+        };
+    }
+
+    {
+        my $sub_tempdir = File::Temp->can('tempdir');
+        *File::Temp::tempdir = sub {
+            my (@in) = @_;
+
+            my $out = $sub_tempdir->(@in);
+            my $dir = "$out";
+
+            Test::MockFile::add_strict_rule_for_filename( [ $dir, qr{^${dir}/} ] => 1 );
+
+            return $out;
+        };
+    }
+
+    return 1;
+}


### PR DESCRIPTION
This commit introduces a few helpers:

    add_strict_rule()
    add_strict_rule_for_filename()
    add_strict_rule_for_command()
    add_strict_rule_generic()

to add custom rules to enhance the strict mode
by authorizing some exceptions.

This replaces #157 