### PR TITLE
Fix Plugin::FileTemp tempfile in scalar context

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 Revision history for Test-MockFile
 
+- Fix for Plugin::FileTemp when calling tempfile in scalar context
+
 0.030   2/22/2022
 - Simplify _strict_mode_violation
 - Introduce new_dir() to allow older dir() syntax.

--- a/lib/Test/MockFile/Plugin/FileTemp.pm
+++ b/lib/Test/MockFile/Plugin/FileTemp.pm
@@ -35,7 +35,7 @@ sub register {
 
             Test::MockFile::add_strict_rule_for_filename( $out[1] => 1 );
 
-            return @out;
+            return wantarray ? @out : $out[0];
         }
     );
 

--- a/t/plugin-filetemp.t
+++ b/t/plugin-filetemp.t
@@ -20,7 +20,7 @@ BEGIN {
 use Test::MockFile 'strict', plugin => 'FileTemp';
 
 ok !$has_filetemp_before_load, "File::Temp is not loaded before Test::MockFile";
-ok $INC{'File/Temp.pm'}, 'File::Temp is loaded';
+ok $INC{'File/Temp.pm'},       'File::Temp is loaded';
 
 require File::Temp;    # not really needed
 
@@ -37,11 +37,18 @@ require File::Temp;    # not really needed
         ok lives { open( my $fh, ">", "$tempdir/here" ) }, "we can open a tempfile under a tempdir";
     }
 
+    # scalar context
+
+    {
+        my $fh = File::Temp::tempfile;
+        ok lives { print {$fh} "test" }, "print to a tempfile - scalar context";
+    }
+
 }
 
 {
     my $dir = File::Temp->newdir();
-    ok opendir( my $dh, "$dir" ), "opendir - newdir";
+    ok opendir( my $dh, "$dir" ),             "opendir - newdir";
     ok open( my $f, '>', "$dir/myfile.txt" ), "open a file created under newdir";
 }
 


### PR DESCRIPTION
Fix File::Temp::tempfile in scalar context when
using Test::MockFile::Plugin::FileTemp