### PR TITLE
Fixup tempfile in scalar context

### DIFF
--- a/lib/Test/MockFile/Plugin/FileTemp.pm
+++ b/lib/Test/MockFile/Plugin/FileTemp.pm
@@ -35,7 +35,10 @@ sub register {
 
             Test::MockFile::add_strict_rule_for_filename( $out[1] => 1 );
 
-            return wantarray ? @out : $out[0];
+            return @out if wantarray;
+
+            File::Temp::unlink0( $out[0], $out[1] );
+            return $out[0];
         }
     );
 

--- a/t/plugin-filetemp.t
+++ b/t/plugin-filetemp.t
@@ -52,4 +52,9 @@ require File::Temp;    # not really needed
     ok open( my $f, '>', "$dir/myfile.txt" ), "open a file created under newdir";
 }
 
+{
+    my $fh = File::Temp::tempfile();
+    is( scalar( ( stat $fh )[3] ), 0, "tempfile in scalar context" );
+}
+
 done_testing;


### PR DESCRIPTION
Fix #173:

Make sure we respect the call of File::Temp::tempfile
in scalar context and create an unlinked file.